### PR TITLE
Corrected variable name.

### DIFF
--- a/deploy/01-deploy-raffle.js
+++ b/deploy/01-deploy-raffle.js
@@ -25,7 +25,8 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
         // Our mock makes it so we don't actually have to worry about sending fund
         await vrfCoordinatorV2Mock.fundSubscription(subscriptionId, FUND_AMOUNT)
     } else {
-        vrfCoordinatorV2Address = networkConfig[chainId]["vrfCoordinatorV2"]
+        // vrfCoordinatorV2Address = networkConfig[chainId]["vrfCoordinatorV2"]
+        vrfCoordinatorV2Address = networkConfig[chainId]["vrfCoordinatorV2Address"]
         subscriptionId = networkConfig[chainId]["subscriptionId"]
     }
 


### PR DESCRIPTION
Changed
```javascript
vrfCoordinatorV2Address = networkConfig[chainId]["vrfCoordinatorV2"]
```
to
```javascript
vrfCoordinatorV2Address = networkConfig[chainId]["vrfCoordinatorV2Address"]
```
As in helper-hardhat-config.js the mock address is defined as "vrfCoordinatorV2Address" and not "vrfCoordinatorV2".